### PR TITLE
Read-only profile page now available

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![version](http://img.shields.io/badge/version-v0.0.1-blue.svg)](#) [![versioning](http://img.shields.io/badge/versioning-semver-blue.svg)](http://semver.org/) [![branching](http://img.shields.io/badge/branching-github%20flow-blue.svg)](https://guides.github.com/introduction/flow/)
 [![Circle CI](https://circleci.com/gh/cairn-software/jornet.svg?style=shield)](https://circleci.com/gh/cairn-software/jornet)
-[![Coverage Status](https://coveralls.io/repos/github/jjwyse/jornet/badge.svg)](https://coveralls.io/github/jjwyse/jornet)
 
 
 ## Overview

--- a/bin/run-tests-coverage.sh
+++ b/bin/run-tests-coverage.sh
@@ -1,3 +1,3 @@
 # Script to find all test files to run
 TESTS=`find src -name "*.test*"`
-NODE_PATH=./src babel-node ./node_modules/istanbul/lib/cli cover node_modules/mocha/bin/_mocha src/test/coverer.js $TESTS -- --require src/test/helper.js --require ignore-styles --recursive --timeout 10000
+NODE_PATH=./src ./node_modules/.bin/nyc mocha $TESTS --require babel-polyfill --compilers js:babel-register --require src/test/helper.js --require ignore-styles --recursive

--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,4 @@ dependencies:
 
 test:
   override:
-    - npm test && npm run coveralls
+    - npm test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "npm run prettify && webpack --bail --progress --env.prod && npm run lint && npm run test:unit:coverage",
     "test:unit": "bin/run-tests.sh",
     "test:unit:coverage": "bin/run-tests-coverage.sh",
-    "coveralls": "cat ./coverage/lcov.info | coveralls",
     "clean-dist": "rm -rf ./dist && mkdir dist",
     "copy-index": "cp src/index.html dist",
     "copy-assets": "cp -R src/assets dist",
@@ -31,6 +30,12 @@
     "url": "https://github.com/jjwyse/jornet/issues"
   },
   "homepage": "https://github.com/jjwyse/jornet#readme",
+  "nyc": {
+    "extension": [
+      ".jsx",
+      ".js"
+    ]
+  },
   "dependencies": {
     "body-parser": "^1.16.1",
     "color": "^1.0.3",
@@ -85,7 +90,6 @@
     "chalk": "^1.1.3",
     "compression": "^1.6.2",
     "compression-webpack-plugin": "^0.3.2",
-    "coveralls": "^2.11.6",
     "css-loader": "^0.26.1",
     "deep-freeze": "0.0.1",
     "enzyme": "^2.4.1",
@@ -108,6 +112,7 @@
     "mockery": "^2.0.0",
     "nock": "^9.0.2",
     "node-sass": "^4.2.0",
+    "nyc": "^11.1.0",
     "opt-cli": "^1.5.1",
     "postcss-loader": "^1.2.2",
     "postcss-smart-import": "^0.6.7",

--- a/src/components/PageTemplates/Layout.jsx
+++ b/src/components/PageTemplates/Layout.jsx
@@ -16,7 +16,7 @@ injectGlobal`
   }
   body {
     margin: 0;
-    font-family: "Open Sans", "Helvetica Neue", "Arial", "Helvetica", "Montserrat", sans-serif;
+    font-family: "Montserrat", "Open Sans", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
     font-weight: 400;
     font-size: 100%;
     line-height: 1.25rem;
@@ -25,7 +25,7 @@ injectGlobal`
     font-size-adjust: 0.5;
   }
   h1, h2, h3, h4, h5, h6 {
-    font-family: "Ubuntu", "Helvetica Neue", "Arial", "Helvetica", "Montserrat", sans-serif;
+    font-family: "Montserrat", "Ubuntu", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
     font-weight: 700;
     margin: 1rem 0;
   }

--- a/src/pages/Login/Profile.jsx
+++ b/src/pages/Login/Profile.jsx
@@ -1,0 +1,61 @@
+import React, {Component, PropTypes} from 'react';
+import TextField from 'material-ui/TextField';
+import {connect} from 'react-redux';
+import styled from 'styled-components';
+
+// Needed for onTouchTap
+import injectTapEventPlugin from 'react-tap-event-plugin';
+injectTapEventPlugin();
+
+const Wrapper = styled.div`
+  margin: 20px;
+  text-align: center;
+`;
+
+const Fields = styled.div`
+  padding: 20px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const ProfilePic = styled.img`
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  margin: 15px 0 15px 15px;
+`;
+
+class Profile extends Component {
+  render() {
+    const {user} = this.props;
+    return (
+      <Wrapper>
+        <Header>
+          <ProfilePic src={`${user.photo}`} />
+          <h1>User Profile</h1>
+        </Header>
+        <Fields>
+          <TextField disabled floatingLabelText={'Email'} value={user.email_address} /> <br />
+          <TextField disabled floatingLabelText={'First Name'} value={user.first_name} /> <br />
+          <TextField disabled floatingLabelText={'Last Name'} value={user.last_name} /> <br />
+          <TextField disabled floatingLabelText={'Home'} value={`${user.city}, ${user.state} - ${user.country}`} />
+          <br />
+        </Fields>
+      </Wrapper>
+    );
+  }
+}
+Profile.propTypes = {
+  user: PropTypes.object.isRequired,
+};
+
+const mapStateToProps = state => {
+  return {
+    user: state.authentication.user,
+  };
+};
+
+export default connect(mapStateToProps)(Profile);

--- a/src/pages/Login/Profile.test.jsx
+++ b/src/pages/Login/Profile.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+
+import Profile from 'pages/Login/Profile';
+
+import {mockStore} from 'test/mocks';
+
+describe('Profile', () => {
+  it('should show the user picture and basic user fields', () => {
+    const state = {
+      authentication: {
+        user: {
+          first_name: 'Foo',
+          last_name: 'Bar',
+          email: 'foo@bar.com',
+          city: 'Denver',
+          state: 'CO',
+          country: 'USA',
+          photo: 'fake_prof_pic.com',
+        },
+      },
+    };
+    const component = mount(
+      <MuiThemeProvider>
+        <Provider store={mockStore(state)}>
+          <Profile />
+        </Provider>
+      </MuiThemeProvider>,
+    );
+
+    // validate heading has "User Profile" header and the img
+    const h1 = component.find('h1');
+    expect(h1.text()).to.equal('User Profile');
+    const img = component.find('img');
+    expect(img.props().src).to.equal(state.authentication.user.photo);
+
+    // email, first_name, last_name, location
+    const labels = component.find('label');
+    expect(labels).to.have.length(4);
+  });
+});

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -4,6 +4,7 @@ import {UserAuthWrapper} from 'redux-auth-wrapper';
 import {routerActions} from 'react-router-redux';
 
 import Login from 'pages/Login/Login';
+import Profile from 'pages/Login/Profile';
 
 import Races from 'pages/Races/Races';
 
@@ -24,6 +25,7 @@ export default (
     // All routes below require authentication
     <Route component={UserIsAuthenticated(LoggedInTemplate)}>
       <IndexRoute component={Races} />
+      <Route path="/profile" component={Profile} />
       <Route path="/races" component={Races} />
     </Route>
 

--- a/src/state/authentication/index.js
+++ b/src/state/authentication/index.js
@@ -28,8 +28,6 @@ const reducer = (state = initialState, {type, payload}) => {
       save(payload);
       return Object.assign({}, state, {user: payload});
     case LOGGED_OUT:
-      invalidate();
-      return {user: null};
     case LOGIN_EXPIRED:
       invalidate();
       return {user: null};

--- a/src/state/authentication/index.test.js
+++ b/src/state/authentication/index.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {reducer, LOGGED_IN} from 'state/authentication';
+import {reducer, LOGGED_IN, LOGGED_OUT} from 'state/authentication';
 
 describe('authentication', () => {
   context('reducer', () => {
@@ -10,6 +10,14 @@ describe('authentication', () => {
       const nextState = reducer(initialState, action);
 
       expect(nextState.user).to.deep.equal(action.payload);
+    });
+
+    it('should support LOGGED_OUT', () => {
+      const initialState = null;
+      const action = {type: LOGGED_OUT};
+      const nextState = reducer(initialState, action);
+
+      expect(nextState.user).to.be.null;
     });
   });
 });


### PR DESCRIPTION
## Highlights
* When clicking "Profile" from the top right menu, you can now see a read-only view of your basic user profile settings.
* Removed dependency on `coveralls` cause I'm sick of that clunky service, and switched to `nyc` to show code coverage information.

## Closes
* Closes #15 
